### PR TITLE
Add Dark Sky icon values and resolve issue when using custom icon-state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -144,7 +144,7 @@ class SimpleWeatherCard extends LitElement {
 
   renderIcon() {
     const icon = this.custom['icon-state']
-      ? this.weather.getIcon(this.custom['icon-state'])
+      ? this.weather.getIcon(this.custom['icon-state'].state)
       : this.weather.icon
     return this.weather.hasState && icon ? html`
       <div class="weather__icon"

--- a/src/weather.js
+++ b/src/weather.js
@@ -15,6 +15,7 @@ import windy from '../icons/windy.svg';
 import humidity from '../icons/humidity.svg';
 
 const ICONS = {
+  "clear-day": sunny,
   "clear-night": clear_night,
   cloudy,
   overcast: cloudy,
@@ -22,12 +23,18 @@ const ICONS = {
   hail: mixed_rain,
   lightning,
   "lightning-rainy": storm,
+  "partly-cloudy-day": mostly_cloudy,
+  "partly-cloudy-night": mostly_cloudy_night,
   partlycloudy: mostly_cloudy,
   pouring: heavy_rain,
+  "rain": rainy,
   rainy,
+  "sleet": mixed_rain,
+  "snow": snowy,
   snowy,
   "snowy-rainy": mixed_rain,
   sunny,
+  "wind": windy,
   windy,
   "windy-variant": windy,
   humidity,


### PR DESCRIPTION
I started the branch to merely add additional values to ICONS to cover values that the Dark Sky API returns that were not already present. In testing, after switching to a custom icon-state and pointing that to a sensor for the Dark Sky icon, the appropriate icon was not rendered despite a matching key in ICONS. After further investigation, I realized the call to getIcon(...) was returning undefined because the icon-state object was being passed in rather than just the state value of the icon-state object. This may help with other instances where a custom icon-state is used (as discussed in #8)