### PR TITLE
Adding math round to 2decimals for precipation

### DIFF
--- a/src/weather.js
+++ b/src/weather.js
@@ -115,7 +115,7 @@ export default class WeatherEntity {
   }
 
   get precipitation() {
-    return this.forecast[0].precipitation || 0;
+    return Math.round( (this.forecast[0].precipitation || 0) *100)/100;
   }
 
   get precipitation_probability() {


### PR DESCRIPTION
Hi there,

It's a fix for the case when weather provider format precipitation is strage/long.
That impacts card rendering, actually the way precipitation format is not really elegant then.

It covers the issue https://github.com/kalkih/simple-weather-card/issues/42

example:
```temperature: 6.6
humidity: 79
pressure: 993.2
wind_bearing: 156.1
wind_speed: 28.8
attribution: >-
  Weather forecast from met.no, delivered by the Norwegian Meteorological
  Institute.
forecast:
  - datetime: '2020-12-29T12:00:00+01:00'
    condition: rainy
    pressure: 991.8
    humidity: 92.6
    wind_bearing: 228.9
    temperature: 5.2
    templow: 2.9
    precipitation: 21.300000000000008
```

Then it's displayed as precipitation: 21.3
![image](https://user-images.githubusercontent.com/47541623/103220615-f7cb2980-4920-11eb-9db8-a0a096ecca0f.png)

