### PR TITLE
Use the right element to get LitElement from

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import style from './style';
 import { handleClick } from './handleClick';
 
 const LitElement = window.LitElement
-  || Object.getPrototypeOf(customElements.get("home-assistant") || customElements.get("hui-view"))
+  || Object.getPrototypeOf(customElements.get("ha-panel-lovelace") || customElements.get("hc-cast"))
 const { html, css } = LitElement.prototype;
 
 const UNITS = {

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import style from './style';
 import { handleClick } from './handleClick';
 
 const LitElement = window.LitElement
-  || Object.getPrototypeOf(customElements.get("ha-panel-lovelace") || customElements.get("hc-cast"))
+  || Object.getPrototypeOf(customElements.get("ha-panel-lovelace") || customElements.get("hc-lovelace"))
 const { html, css } = LitElement.prototype;
 
 const UNITS = {


### PR DESCRIPTION
The `home-assistant` element is not a normal `LitElement`, but has a bunch of mixins giving unwanted side effects.

Besides that, `hui-view` is no longer a `LitElement` but a `UpdatingElement`, so should not be used as a fallback.