### PR TITLE
Fix local-conditional-card rendering: trigger hass setter in connectedCallback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,14 @@ class SimpleWeatherCard extends LitElement {
     this.custom = {};
   }
 
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._hass && this.config && !this.entity) {
+      this.hass = this._hass; // Trigger setter logic
+    }
+  }
+
   static styles = style(css);
 
   static get properties() {
@@ -47,8 +55,11 @@ class SimpleWeatherCard extends LitElement {
     const { custom, entity } = this.config;
 
     this._hass = hass;
-    const entityObj = hass.states[entity];
-    if (entityObj && this.entity !== entityObj) {
+    const entityObj = hass && hass.states && hass.states[entity];
+    if (!entityObj) return;
+
+    if (this.entity !== entityObj) {
+
       this.entity = entityObj;
       this.weather = new WeatherEntity(hass, entityObj);
     }


### PR DESCRIPTION
This PR fixes an issue where the simple-weather-card wouldn’t show up when used inside [local-conditional-card](https://github.com/PiotrMachowski/Home-Assistant-Lovelace-Local-Conditional-card). This change ensures the card finishes setting itself up before getting data.